### PR TITLE
Use plugin manager from pull-request or main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,24 +26,24 @@ jobs:
       - name: Install fish shell
         uses: fish-actions/install-fish@v1.1.0
       - if: github.event_name != 'pull_request'
-        name: Install plugin manager (main)
+        name: Install plugin manager using action from main branch
         uses: fish-shop/install-plugin-manager@main
         with:
           plugin-manager: ${{ matrix.plugin-manager }}
       - if: github.event_name == 'pull_request'
-        name: Install plugin manager (pull-request)
+        name: Install plugin manager using action from pull-request branch
         uses: ./.
         with:
           plugin-manager: ${{ matrix.plugin-manager }}
-      - name: Check plugin manager installed
-        if: matrix.plugin-manager == 'fisher'
+      - if: matrix.plugin-manager == 'fisher'
+        name: Check Fisher was installed
         run: type -q fisher
         shell: fish {0}
-      - name: Check plugin manager installed
-        if: matrix.plugin-manager == 'oh-my-fish'
+      - if: matrix.plugin-manager == 'oh-my-fish'
+        name: Check Oh My Fish was installed
         run: type -q omf
         shell: fish {0}
-      - name: Check plugin manager installed
-        if: matrix.plugin-manager == 'plug.fish'
+      - if: matrix.plugin-manager == 'plug.fish'
+        name: Check plug.fish was installed
         run: type -q plug
         shell: fish {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install fish shell
         uses: fish-actions/install-fish@v1.1.0
-      - name: Install plugin manager
-        uses: fish-shop/install-plugin-manager@1.0.0
+      - if: github.event_name != 'pull_request'
+        name: Install plugin manager (main)
+        uses: fish-shop/install-plugin-manager@main
+        with:
+          plugin-manager: ${{ matrix.plugin-manager }}
+      - if: github.event_name == 'pull_request'
+        name: Install plugin manager (pull-request)
+        uses: ./.
         with:
           plugin-manager: ${{ matrix.plugin-manager }}
       - name: Check plugin manager installed


### PR DESCRIPTION
Conditionally install the `fish-shop/install-plugin-manager` action from either `main` or the pull-request branch depending on context.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
